### PR TITLE
Close trading clients to avoid unclosed session warnings

### DIFF
--- a/src/account.py
+++ b/src/account.py
@@ -1,4 +1,5 @@
 import os
+import inspect
 from dotenv import load_dotenv
 from x10.perpetual.accounts import StarkPerpetualAccount
 from x10.perpetual.trading_client import PerpetualTradingClient
@@ -41,3 +42,13 @@ class TradingAccount:
 
     def get_account(self) -> StarkPerpetualAccount:
         return self.stark_account
+
+    async def close(self) -> None:
+        """Close underlying HTTP sessions for created clients."""
+        for client in (self.async_client, self.blocking_client):
+            close_method = getattr(client, "close", None)
+            if close_method:
+                if inspect.iscoroutinefunction(close_method):
+                    await close_method()
+                else:
+                    close_method()

--- a/src/main.py
+++ b/src/main.py
@@ -18,17 +18,20 @@ async def main():
     account = TradingAccount()
     client = account.get_blocking_client()
 
-    # 1. Create a limit BUY order
-    order = await place_limit_order(
-        client=client,
-        market="BTC-USD",
-        quantity=Decimal("0.01"),
-        price=Decimal("70000"),
-        side=OrderSide.BUY,
-    )
+    try:
+        # 1. Create a limit BUY order
+        order = await place_limit_order(
+            client=client,
+            market="BTC-USD",
+            quantity=Decimal("0.01"),
+            price=Decimal("70000"),
+            side=OrderSide.BUY,
+        )
 
-    # 2. Cancel the order
-    await cancel_order(client, order_id=order.id)
+        # 2. Cancel the order
+        await cancel_order(client, order_id=order.id)
+    finally:
+        await account.close()
     
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `TradingAccount.close` to gracefully close HTTP sessions
- ensure `main` closes account after placing and cancelling orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689479aefee083308a5b1597b4ea9f79