### PR TITLE
Add automatic TP/SL placement for orders

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,31 +4,25 @@ from decimal import Decimal
 
 from x10.perpetual.orders import OrderSide
 
-from x10.perpetual.orderbook import OrderBook
-from x10.perpetual.configuration import MAINNET_CONFIG
-
-from utils import clean_account, setup_logging
+from utils import setup_logging
 
 from account import TradingAccount
 
-from order_manager import place_limit_order, cancel_order
+from order_manager import place_order_with_tp_sl
 
 async def main():
     setup_logging()
     account = TradingAccount()
     client = account.get_blocking_client()
 
-    # 1. Create a limit BUY order
-    order = await place_limit_order(
+    # Place a BUY order with attached TP and SL
+    await place_order_with_tp_sl(
         client=client,
         market="BTC-USD",
         quantity=Decimal("0.01"),
         price=Decimal("70000"),
         side=OrderSide.BUY,
     )
-
-    # 2. Cancel the order
-    await cancel_order(client, order_id=order.id)
     
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/order_manager.py
+++ b/src/order_manager.py
@@ -1,5 +1,6 @@
 # order_manager.py
 from decimal import Decimal
+from typing import Tuple
 from x10.perpetual.orders import OrderSide
 from x10.perpetual.simple_client.simple_trading_client import BlockingTradingClient
 
@@ -43,3 +44,67 @@ async def cancel_order(client: BlockingTradingClient, order_id: str):
     """
     await client.cancel_order(order_id=order_id)
     print(f"❌ Order {order_id} canceled")
+
+
+async def place_order_with_tp_sl(
+    client: BlockingTradingClient,
+    market: str,
+    quantity: Decimal,
+    price: Decimal,
+    side: OrderSide,
+) -> Tuple[object, object, object]:
+    """
+    Place an order and automatically attach a take profit and stop loss.
+
+    :param client: BlockingTradingClient
+    :param market: market name (ex: BTC-USD)
+    :param quantity: size of the order
+    :param price: entry price
+    :param side: OrderSide.BUY or OrderSide.SELL for the entry
+    :return: tuple containing entry, tp and sl orders
+    """
+
+    # 1. Place the entry order as maker
+    entry_order = await place_limit_order(
+        client=client,
+        market=market,
+        quantity=quantity,
+        price=price,
+        side=side,
+        post_only=True,
+    )
+
+    # Determine TP and SL prices relative to the entry
+    tp_factor = Decimal("1.0005")
+    sl_factor = Decimal("0.9995")
+
+    if side == OrderSide.BUY:
+        tp_price = price * tp_factor
+        sl_price = price * sl_factor
+        exit_side = OrderSide.SELL
+    else:
+        tp_price = price * sl_factor
+        sl_price = price * tp_factor
+        exit_side = OrderSide.BUY
+
+    # 2. Place the take profit order (maker)
+    tp_order = await place_limit_order(
+        client=client,
+        market=market,
+        quantity=quantity,
+        price=tp_price,
+        side=exit_side,
+        post_only=True,
+    )
+
+    # 3. Place the stop loss order (taker)
+    sl_order = await place_limit_order(
+        client=client,
+        market=market,
+        quantity=quantity,
+        price=sl_price,
+        side=exit_side,
+        post_only=False,
+    )
+
+    return entry_order, tp_order, sl_order


### PR DESCRIPTION
## Summary
- add helper to open orders with automatic take-profit and stop-loss
- update main script to use new helper

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68948e6015cc8330bc5020f291b4c2f9