### PR TITLE
Persist external IDs and handle missing open orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Persistent state for MarketMaker external IDs
+external_id_counter.txt


### PR DESCRIPTION
## Summary
- persist a monotonically increasing external ID counter across restarts
- cancel server orders missing an external ID so they can be regenerated

## Testing
- `python -m py_compile src/maker_main.py`


------
https://chatgpt.com/codex/tasks/task_e_689f2d3688e08330b71d7da184ddd162