### PR TITLE
Use UUIDs for external IDs and migrate from SQLite store

### DIFF
--- a/src/id_generator.py
+++ b/src/id_generator.py
@@ -1,48 +1,30 @@
 from __future__ import annotations
 
-import sqlite3
 import uuid
 from pathlib import Path
 from typing import Optional
 
 
 class SqliteExternalIdGenerator:
-    """Generate unique identifiers using a SQLite AUTOINCREMENT column.
+    """Generate unique identifiers.
 
-    SQLite's built-in locking makes the increments safe even when accessed
-    by multiple processes concurrently.
+    This class historically relied on a SQLite AUTOINCREMENT column to produce
+    sequential identifiers. Such identifiers could be reused if the backing
+    database file was ever deleted or reset.  The generator now delegates to
+    ``uuid_external_id`` which relies solely on ``uuid.uuid4`` and therefore
+    guarantees uniqueness regardless of any local state.
     """
 
-    def __init__(self, db_path: Path):
-        self.db_path = Path(db_path)
-        self._init_db()
-
-    def _init_db(self) -> None:
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS ids (value INTEGER PRIMARY KEY AUTOINCREMENT)"
-            )
-            conn.commit()
+    def __init__(self, db_path: Path | None = None):
+        # ``db_path`` is retained for backwards compatibility; it is no longer
+        # used directly by the UUID-based generator.
+        self.db_path = Path(db_path) if db_path is not None else None
 
     def next_id(
         self, prefix: str = "", side: Optional[str] = None, idx: Optional[int] = None
     ) -> str:
-        """Return a new sequential identifier string."""
-        with sqlite3.connect(self.db_path) as conn:
-            # BEGIN IMMEDIATE obtains a reserved lock to serialize writers
-            conn.execute("BEGIN IMMEDIATE")
-            cur = conn.execute("INSERT INTO ids DEFAULT VALUES")
-            value = cur.lastrowid
-            conn.commit()
-
-        parts = [prefix.rstrip("_")]
-        if side:
-            parts.append(side)
-        if idx is not None:
-            parts.append(str(idx))
-        parts.append(str(value))
-        return "_".join(filter(None, parts))
+        """Return a new unique identifier string."""
+        return uuid_external_id(prefix, side, idx)
 
 
 def uuid_external_id(


### PR DESCRIPTION
## Summary
- switch SqliteExternalIdGenerator to use UUID-based IDs
- migrate legacy external-id SQLite files and update maker_main to use UUID generator

## Testing
- `pytest`
- `python -m py_compile src/id_generator.py src/maker_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06dc17b208330bd6c9c216967d37a