### PR TITLE
Handle request timeouts with backoff

### DIFF
--- a/src/backoff_utils.py
+++ b/src/backoff_utils.py
@@ -1,26 +1,42 @@
-# backoff_utils.py
-import asyncio, random, re
+"""Helper to retry REST calls with exponential backoff."""
+
+import asyncio
+import os
+import random
+import re
+
+
+# Maximum duration allowed for each REST call.
+REQUEST_TIMEOUT = float(os.getenv("MM_REQUEST_TIMEOUT", "10"))
+
 
 async def call_with_retries(op, *, limiter, max_attempts=6, base_delay=0.25):
-    # op: async function with no args (lambda) that does the REST call
+    """Execute ``op`` with retry/backoff logic.
+
+    ``op`` is an async function (no-arg lambda) performing the REST call.
+    ``limiter`` controls the request rate.
+    ``max_attempts`` and ``base_delay`` configure exponential backoff.
+    """
+
     attempt = 0
     while True:
         attempt += 1
         await limiter.acquire()
         try:
-            return await op()
-        except Exception as e:
+            return await asyncio.wait_for(op(), timeout=REQUEST_TIMEOUT)
+        except Exception as e:  # noqa: PERF203 - we want to catch broadly
             msg = str(e)
+            is_timeout = isinstance(e, asyncio.TimeoutError)
             is_429 = " 429 " in msg or "Too Many Requests" in msg
             is_5xx = " 5" in msg[:5] or " 50" in msg or " 502 " in msg or " 503 " in msg or " 504 " in msg
-            if not (is_429 or is_5xx):
+            if not (is_timeout or is_429 or is_5xx):
                 raise
             if attempt >= max_attempts:
                 raise
-            # Retry-After seconds if present
-            m = re.search(r"Retry-After\"?:\s*\"?(\d+)", msg, re.IGNORECASE)
+            # Retry-After seconds if present (HTTP errors only)
+            m = None if is_timeout else re.search(r"Retry-After\"?:\s*\"?(\d+)", msg, re.IGNORECASE)
             ra = float(m.group(1)) if m else None
             # Exponential backoff + jitter
             delay = ra if ra is not None else (base_delay * (2 ** (attempt - 1)))
-            delay *= (0.8 + 0.4 * random.random())
+            delay *= 0.8 + 0.4 * random.random()
             await asyncio.sleep(min(delay, 5.0))

--- a/tests/test_backoff_utils.py
+++ b/tests/test_backoff_utils.py
@@ -1,0 +1,38 @@
+import os
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src/ is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def _reload_module():
+    import backoff_utils
+    importlib.reload(backoff_utils)
+    return backoff_utils
+
+
+@pytest.mark.asyncio
+async def test_retry_on_timeout():
+    os.environ["MM_REQUEST_TIMEOUT"] = "0.05"
+    backoff_utils = _reload_module()
+    attempts = 0
+
+    async def op():
+        nonlocal attempts
+        attempts += 1
+        await asyncio.sleep(0.1)
+
+    class DummyLimiter:
+        async def acquire(self):
+            pass
+
+    limiter = DummyLimiter()
+    with pytest.raises(asyncio.TimeoutError):
+        await backoff_utils.call_with_retries(op, limiter=limiter, max_attempts=3, base_delay=0.01)
+
+    assert attempts == 3


### PR DESCRIPTION
## Summary
- wrap API operations in `asyncio.wait_for` with configurable `REQUEST_TIMEOUT`
- retry on `asyncio.TimeoutError` using same backoff as 429/5xx
- add test verifying timeout retries

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a08f8e7ce483308e42c6b995e6503c