### PR TITLE
Purge excess open orders during reconciliation

### DIFF
--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -134,7 +134,8 @@ async def test_detect_reconcile_marks_price_drift_order():
     mm._market = types.SimpleNamespace(name="BTC")
     mm._buy_slots = [Slot("mm_1", Decimal("1"))]
 
-    missing, orphans = await mm.detect_reconcile()
+    missing, orphans, open_orders = await mm.detect_reconcile()
 
     assert missing == [(mm._buy_slots, 0)]
     assert orphans == [drift_order]
+    assert open_orders == [drift_order]


### PR DESCRIPTION
## Summary
- extend reconciliation to purge excess open orders via mass cancel
- expose full open order list from `detect_reconcile`
- add configurable margin for open order limit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1d946091c8330a0614d15d879cdb4