### PR TITLE
Gracefully stop stale orderbook in maker refresh loop

### DIFF
--- a/src/maker_main.py
+++ b/src/maker_main.py
@@ -402,9 +402,14 @@ class MarketMaker:
             is_closed = bool(getattr(ob, "is_closed", False) or getattr(ob, "closed", False))
             if age > MAX_OB_AGE_SEC or is_closed:
                 try:
-                    await ob.close()
+                    if hasattr(ob, "stop_orderbook"):
+                        await ob.stop_orderbook()
+                    elif hasattr(ob, "aclose"):
+                        await ob.aclose()
+                    else:
+                        await ob.close()
                 except Exception:
-                    logger.exception("Error closing stale OrderBook")
+                    logger.exception("Error shutting down stale OrderBook")
                 self._order_book = await self._create_order_book()
                 logger.info("OrderBook stream reconnected")
 


### PR DESCRIPTION
## Summary
- Stop a stale `OrderBook` via `stop_orderbook` or `aclose` when refreshing
- Improve error logging when shutting down old orderbooks

## Testing
- `pytest -q`
- Manual async test simulating stale orderbook reconnection

------
https://chatgpt.com/codex/tasks/task_e_68a2228688848330bb0aeeb94f70109c