### PR TITLE
Add async shutdown support for order book watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ src/
   account.py            # loads keys, builds TradingAccount & clients
   rate_limit.py         # token-bucket limiter
   backoff_utils.py      # retry with exponential backoff
+  services/orderbook.py # lightweight order book watcher
+```
+
+Example of the order book watcher:
+
+```python
+from services.orderbook import OrderBookWatcher
+
+watcher = OrderBookWatcher("BTC-USD")
+await watcher.start()
+print(watcher.get_best_bid(), watcher.get_best_ask())
+await watcher.stop()  # release network resources
 ```
 
 ---

--- a/src/services/orderbook.py
+++ b/src/services/orderbook.py
@@ -1,17 +1,40 @@
 from x10.perpetual.orderbook import OrderBook
 from x10.perpetual.configuration import MAINNET_CONFIG
 
+
 class OrderBookWatcher:
-    def __init__(self, market_name="BTC-USD"):
+    """Light wrapper around the SDK order book stream.
+
+    Use :meth:`start` to begin streaming and :meth:`stop` to gracefully
+    close the underlying connection when finished.
+    """
+
+    def __init__(self, market_name: str = "BTC-USD"):
         self.market_name = market_name
         self.orderbook = None
 
-    async def start(self):
+    async def start(self) -> None:
+        """Start watching the market's order book."""
         self.orderbook = await OrderBook.create(
             endpoint_config=MAINNET_CONFIG,
-            market_name=self.market_name
+            market_name=self.market_name,
         )
         await self.orderbook.start_orderbook()
+
+    async def stop(self) -> None:
+        """Stop the underlying order book stream and release resources."""
+        ob = self.orderbook
+        if not ob:
+            return
+        try:
+            if hasattr(ob, "stop_orderbook"):
+                await ob.stop_orderbook()
+            elif hasattr(ob, "aclose"):
+                await ob.aclose()
+            else:
+                await ob.close()
+        finally:
+            self.orderbook = None
 
     def get_best_bid(self):
         return self.orderbook.best_bid()


### PR DESCRIPTION
## Summary
- add an asynchronous `stop` method to `OrderBookWatcher`
- document order book watcher usage with start/stop example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a226cd6e1083309d1b7ab2e4be6a69