### PR TITLE
Add TokenBucket docstrings and rate limiting tests

### DIFF
--- a/src/rate_limit.py
+++ b/src/rate_limit.py
@@ -8,6 +8,21 @@ def _env_int(name, default):
         return default
 
 class TokenBucket:
+    """Asynchronous token bucket rate limiter.
+
+    A token bucket keeps a pool of ``capacity`` tokens which are replenished
+    at a constant rate of ``refill_per_sec`` tokens every second.  Consumers
+    call :meth:`acquire` to remove tokens; if not enough are available the
+    coroutine will wait until the bucket refills.
+
+    Parameters
+    ----------
+    capacity:
+        Maximum number of tokens the bucket can hold.
+    refill_per_sec:
+        Number of tokens added to the bucket every second.
+    """
+
     def __init__(self, capacity: int, refill_per_sec: float):
         self.capacity = capacity
         self.tokens = capacity
@@ -33,6 +48,18 @@ class TokenBucket:
         asyncio.create_task(_notify())
 
     async def acquire(self, n: int = 1):
+        """Acquire ``n`` tokens from the bucket.
+
+        The call blocks asynchronously until at least ``n`` tokens are
+        available. Tokens are replenished based on the elapsed time since
+        the previous acquisition.
+
+        Parameters
+        ----------
+        n:
+            Number of tokens to remove from the bucket. Defaults to ``1``.
+        """
+
         async with self._cond:
             while True:
                 now = time.monotonic()
@@ -47,6 +74,24 @@ class TokenBucket:
                 await self._cond.wait()
 
 def build_rate_limiter():
+    """Create a :class:`TokenBucket` configured from environment variables.
+
+    The limiter is tuned via the following variables:
+
+    ``MM_MARKET_MAKER``
+        When set to ``"1"`` use market-maker defaults for higher throughput.
+    ``MM_RATE_LIMIT_RPS``
+        Desired refill rate in requests per second.
+    ``MM_RATE_LIMIT_BURST``
+        Maximum burst size; defaults to double the refill rate.
+
+    Returns
+    -------
+    TokenBucket
+        A token bucket limiting callers to ``rps`` tokens per second with a
+        burst capacity of ``burst``.
+    """
+
     # If you’ve got MM rate-limit, set MM_MARKET_MAKER=1
     is_mm = os.getenv("MM_MARKET_MAKER", "0") == "1"
     # Default “safe” profiles (override with env if you want)

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,40 @@
+import asyncio
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src/ is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from rate_limit import TokenBucket
+
+
+@pytest.mark.asyncio
+async def test_tokens_refill_over_time():
+    bucket = TokenBucket(capacity=5, refill_per_sec=10)
+    # Drain the bucket completely
+    for _ in range(5):
+        await bucket.acquire()
+
+    # Allow some time for tokens to refill
+    await asyncio.sleep(0.3)
+
+    # Trigger token recalculation without consuming
+    await bucket.acquire(0)
+
+    assert bucket.tokens == pytest.approx(3, abs=0.3)
+
+
+@pytest.mark.asyncio
+async def test_acquire_waits_for_refill():
+    bucket = TokenBucket(capacity=1, refill_per_sec=5)
+    await bucket.acquire()
+
+    start = time.monotonic()
+    await bucket.acquire()
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.18
+    assert elapsed < 0.5


### PR DESCRIPTION
## Summary
- document TokenBucket rate limiter and its acquire method
- describe build_rate_limiter environment configuration
- test token refill timing and rate limiting behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a70712aaa88330842a013e153f44e0