### PR TITLE
fix: call orderbook methods

### DIFF
--- a/src/sigma_threshold.py
+++ b/src/sigma_threshold.py
@@ -68,8 +68,8 @@ async def _run() -> None:
 
     try:
         while True:
-            bid = getattr(orderbook, "best_bid", None)
-            ask = getattr(orderbook, "best_ask", None)
+            bid = orderbook.best_bid()
+            ask = orderbook.best_ask()
             if bid and ask:
                 mid = float((bid.price + ask.price) / 2)
                 mid_history.append(mid)
@@ -81,7 +81,7 @@ async def _run() -> None:
                 logger.info("sigma=%.5f threshold=%.5f", sigma, threshold)
             await asyncio.sleep(REFRESH_INTERVAL_SEC)
     finally:
-        await orderbook.close()
+        orderbook.stop_orderbook()
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- call OrderBook.best_bid() and best_ask() instead of accessing methods as attributes
- stop stream via stop_orderbook instead of missing close()

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2281b6288330b6f714e384a0a11f