### PR TITLE
Handle unexpected errors in trading loop

### DIFF
--- a/src/hybrid_main.py
+++ b/src/hybrid_main.py
@@ -293,14 +293,18 @@ class HybridTrader:
     async def _trading_loop(self) -> None:
         """Dispatch to the appropriate mode's trading function."""
         while not self._closing.is_set():
-            await self._check_mm_fills()
-            distance = self._distance_to_entry()
-            logger.info("mode=%s distance_to_entry=%.5f", self._mode, distance)
-            if self._mode == "calm":
-                await self._market_make()
-            else:
-                await self._scalp_momentum()
-            await asyncio.sleep(REFRESH_INTERVAL_SEC)
+            try:
+                await self._check_mm_fills()
+                distance = self._distance_to_entry()
+                logger.info("mode=%s distance_to_entry=%.5f", self._mode, distance)
+                if self._mode == "calm":
+                    await self._market_make()
+                else:
+                    await self._scalp_momentum()
+                await asyncio.sleep(REFRESH_INTERVAL_SEC)
+            except Exception:  # noqa: BLE001
+                logger.exception("trading loop aborted")
+                await asyncio.sleep(REFRESH_INTERVAL_SEC)
 
     def _distance_to_entry(self) -> float:
         """Return relative distance of mid price from VWAP for entry."""


### PR DESCRIPTION
## Summary
- Wrap trading loop in try/except and log failures with `logger.exception`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad94aac3608330875d4e7b2803c902