### PR TITLE
Handle rejected grid orders

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -222,6 +222,18 @@ class GridTrader:
                     getattr(result, "data", None) if result else None,
                 )
                 raise RuntimeError(getattr(result, "error", "empty response"))
+            status = getattr(getattr(result, "data", None), "status", None)
+            if status != "PLACED":
+                logger.error(
+                    "order rejected | market=%s side=%s idx=%d price=%s status=%s",
+                    self._market.name if self._market else "?",
+                    side.name,
+                    idx,
+                    str(price),
+                    status,
+                )
+                slots[idx] = Slot(None, None, side)
+                return
             slots[idx] = Slot(new_external_id, price, side)
         except Exception as e:
             msg = str(e).lower()

--- a/tests/test_grid_order_rejection.py
+++ b/tests/test_grid_order_rejection.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import logging
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Set env vars to avoid interactive prompts during import
+os.environ.setdefault("GRID_MARKET", "TEST-USD")
+os.environ.setdefault("GRID_LEVELS", "1")
+os.environ.setdefault("GRID_MIN_PRICE", "0")
+os.environ.setdefault("GRID_MAX_PRICE", "100")
+
+# Ensure src/ is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from grid_main import GridTrader, OrderSide  # noqa: E402
+
+
+class StubAccount:
+    endpoint_config = SimpleNamespace()
+
+    def get_blocking_client(self):  # pragma: no cover - simple stub
+        return SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_ensure_order_logs_rejection(monkeypatch, caplog):
+    trader = GridTrader(
+        account=StubAccount(),
+        market_name="TEST-USD",
+        grid_step=Decimal("1"),
+        level_count=1,
+        order_size_usd=Decimal("10"),
+        lower_bound=Decimal("0"),
+        upper_bound=Decimal("100"),
+    )
+    trader._market = SimpleNamespace(
+        name="TEST-USD",
+        trading_config=SimpleNamespace(
+            calculate_order_size_from_value=lambda value, price: value / price,
+            min_order_size=Decimal("0"),
+        ),
+    )
+
+    async def fake_create_and_place_order(**kwargs):
+        return SimpleNamespace(data=SimpleNamespace(status="REJECTED"), error=None)
+
+    trader.client = SimpleNamespace(create_and_place_order=fake_create_and_place_order)
+
+    async def fake_call_with_retries(fn, limiter=None):
+        return await fn()
+
+    monkeypatch.setattr("grid_main.call_with_retries", fake_call_with_retries)
+
+    caplog.set_level(logging.ERROR, logger="extended_bot")
+
+    await trader._ensure_order(trader._buy_slots, OrderSide.BUY, 0, Decimal("50"))
+
+    assert any("order rejected" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- check create_and_place_order status in `GridTrader._ensure_order`
- log and clear slot when order status is not PLACED
- add regression test for order rejection logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b163b8c4588330bbe076051815b671