### PR TITLE
Add info logging to grid strategy

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -114,6 +114,7 @@ class GridTrader:
 
     # ------------------------------------------------------------------
     async def start(self) -> None:
+        setup_logging(logging.INFO)
         markets = await self.client.get_markets()
         if self.market_name not in markets:
             raise RuntimeError(f"Market {self.market_name} introuvable.")
@@ -163,6 +164,13 @@ class GridTrader:
     async def _refresh_loop(self) -> None:
         while not self._closing.is_set():
             await self._update_grid()
+            active_buys = sum(1 for s in self._buy_slots if s.external_id)
+            active_sells = sum(1 for s in self._sell_slots if s.external_id)
+            logger.info(
+                "grid refresh | active_buys=%d active_sells=%d",
+                active_buys,
+                active_sells,
+            )
             await asyncio.sleep(REFRESH_INTERVAL_SEC)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Configure logging at INFO level when starting grid trader
- Log active buy and sell orders each grid refresh for visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1de343a148330b85b566b7d6e3108