### PR TITLE
Handle missing close method on OrderBook

### DIFF
--- a/src/hybrid_main.py
+++ b/src/hybrid_main.py
@@ -32,7 +32,7 @@ from account import TradingAccount
 from rate_limit import build_rate_limiter
 from backoff_utils import call_with_retries
 from id_generator import uuid_external_id
-from utils import logger,setup_logging,logging
+from utils import logger,setup_logging,logging, close_orderbook
 from regime.calibration import VolatilityCalibrator
 from strategy.quoting import Quoter
 
@@ -218,7 +218,8 @@ class HybridTrader:
                     pass
 
         if self._order_book:
-            await self._order_book.close()
+            await close_orderbook(self._order_book)
+            self._order_book = None
         await self.account.close()
 
     # ------------------------------------------------------------------

--- a/src/services/orderbook.py
+++ b/src/services/orderbook.py
@@ -1,5 +1,6 @@
 from x10.perpetual.orderbook import OrderBook
 from x10.perpetual.configuration import MAINNET_CONFIG
+from utils import close_orderbook
 
 
 class OrderBookWatcher:
@@ -27,12 +28,7 @@ class OrderBookWatcher:
         if not ob:
             return
         try:
-            if hasattr(ob, "stop_orderbook"):
-                await ob.stop_orderbook()
-            elif hasattr(ob, "aclose"):
-                await ob.aclose()
-            else:
-                await ob.close()
+            await close_orderbook(ob)
         finally:
             self.orderbook = None
 


### PR DESCRIPTION
## Summary
- add helper to gracefully close OrderBook regardless of SDK method names
- apply new helper in trading scripts and watcher
- add regression test for order books lacking `close`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b31e717c7483309a98adc875e81ea4