### PR TITLE
Handle order-book shutdown across strategies

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -24,7 +24,7 @@ from account import TradingAccount
 from rate_limit import build_rate_limiter
 from backoff_utils import call_with_retries
 from id_generator import uuid_external_id
-from utils import logger, setup_logging
+from utils import logger, setup_logging, _close_order_book
 import logging
 
 # --- Configuration ----------------------------------------------------------------------
@@ -146,7 +146,7 @@ class GridTrader:
                 mid = Decimal(str(last))
         if mid is None:
             if self._order_book:
-                await self._order_book.close()
+                await _close_order_book(self._order_book)
             raise RuntimeError("Unable to determine current mid price")
 
         if mid <= self.min_price or mid >= self.max_price:
@@ -156,7 +156,7 @@ class GridTrader:
                 str(self.min_price),
                 str(self.max_price),
             )
-            await self._order_book.close()
+            await _close_order_book(self._order_book)
             self._order_book = None
             raise RuntimeError("grid bounds do not bracket current price")
 
@@ -196,7 +196,7 @@ class GridTrader:
             except asyncio.CancelledError:
                 pass
         if self._order_book:
-            await self._order_book.close()
+            await _close_order_book(self._order_book)
         await self.account.close()
 
     async def _refresh_loop(self) -> None:

--- a/src/hybrid_main.py
+++ b/src/hybrid_main.py
@@ -32,7 +32,7 @@ from account import TradingAccount
 from rate_limit import build_rate_limiter
 from backoff_utils import call_with_retries
 from id_generator import uuid_external_id
-from utils import logger,setup_logging,logging
+from utils import logger,setup_logging,logging,_close_order_book
 from regime.calibration import VolatilityCalibrator
 from strategy.quoting import Quoter
 
@@ -218,7 +218,7 @@ class HybridTrader:
                     pass
 
         if self._order_book:
-            await self._order_book.close()
+            await _close_order_book(self._order_book)
         await self.account.close()
 
     # ------------------------------------------------------------------

--- a/src/maker_main.py
+++ b/src/maker_main.py
@@ -17,7 +17,7 @@ from account import TradingAccount
 from rate_limit import build_rate_limiter
 from backoff_utils import call_with_retries
 from id_generator import uuid_external_id
-from utils import logger, setup_logging, logging
+from utils import logger, setup_logging, logging, _close_order_book
 
 
 # --- Paramètres de prod (surcouchables par variables d'env) ---
@@ -150,7 +150,7 @@ class MarketMaker:
                 pass
 
         if self._order_book:
-            await self._order_book.close()
+            await _close_order_book(self._order_book)
         await self.account.close()
 
     MM_PREFIX = "mm_"

--- a/tests/test_close_order_book.py
+++ b/tests/test_close_order_book.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+import pytest
+
+# ensure src directory is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from utils import _close_order_book
+
+
+@pytest.mark.asyncio
+async def test_stop_orderbook_preferred():
+    class Dummy:
+        def __init__(self):
+            self.called = None
+        async def stop_orderbook(self):
+            self.called = "stop"
+    ob = Dummy()
+    await _close_order_book(ob)
+    assert ob.called == "stop"
+
+
+@pytest.mark.asyncio
+async def test_aclose_fallback():
+    class Dummy:
+        def __init__(self):
+            self.called = None
+        async def aclose(self):
+            self.called = "aclose"
+    ob = Dummy()
+    await _close_order_book(ob)
+    assert ob.called == "aclose"
+
+
+@pytest.mark.asyncio
+async def test_close_last_resort_handles_sync_and_async():
+    class AsyncDummy:
+        def __init__(self):
+            self.called = None
+        async def close(self):
+            self.called = "async"
+    class SyncDummy:
+        def __init__(self):
+            self.called = False
+        def close(self):
+            self.called = True
+    # Async close
+    ob_async = AsyncDummy()
+    await _close_order_book(ob_async)
+    assert ob_async.called == "async"
+    # Sync close
+    ob_sync = SyncDummy()
+    await _close_order_book(ob_sync)
+    assert ob_sync.called is True


### PR DESCRIPTION
## Summary
- add `_close_order_book` helper selecting `stop_orderbook`, `aclose`, or `close`
- use helper in grid, maker, and hybrid traders when shutting down order books
- test helper behaviour for different order book implementations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b326fd779c8330b70899770a82059f