### PR TITLE
Use market stats for mid price fallback in grid bot

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -139,11 +139,38 @@ class GridTrader:
         if bid and ask:
             mid = (Decimal(bid.price) + Decimal(ask.price)) / 2
         else:
-            last = getattr(self._market, "last_price", None) or getattr(
-                self._market, "oracle_price", None
+            stats = getattr(self._market, "market_stats", None) or getattr(
+                self._market, "marketStats", None
             )
-            if last is not None:
-                mid = Decimal(str(last))
+            if stats:
+                bid_px = getattr(stats, "bidPrice", None) or getattr(
+                    stats, "bid_price", None
+                )
+                ask_px = getattr(stats, "askPrice", None) or getattr(
+                    stats, "ask_price", None
+                )
+                if bid_px is not None and ask_px is not None:
+                    try:
+                        mid = (Decimal(str(bid_px)) + Decimal(str(ask_px))) / 2
+                    except Exception:
+                        mid = None
+                if mid is None:
+                    for attr in (
+                        "markPrice",
+                        "mark_price",
+                        "indexPrice",
+                        "index_price",
+                        "lastPrice",
+                        "last_price",
+                    ):
+                        raw = getattr(stats, attr, None)
+                        if raw is not None:
+                            try:
+                                mid = Decimal(str(raw))
+                                break
+                            except Exception:
+                                mid = None
+            
         if mid is None:
             # Final fallback: query ticker or recent trades via the client
             price: Decimal | None = None

--- a/tests/test_grid_start_mid.py
+++ b/tests/test_grid_start_mid.py
@@ -68,6 +68,7 @@ async def test_start_uses_live_mid_for_sides(monkeypatch):
         market = SimpleNamespace(
             name="TEST-USD",
             trading_config=SimpleNamespace(price_precision=1),
+            market_stats=SimpleNamespace(bidPrice=None, askPrice=None),
         )
         return {"TEST-USD": market}
 
@@ -118,6 +119,7 @@ async def test_start_aborts_when_mid_outside_bounds(monkeypatch):
         market = SimpleNamespace(
             name="TEST-USD",
             trading_config=SimpleNamespace(price_precision=1),
+            market_stats=SimpleNamespace(bidPrice=None, askPrice=None),
         )
         return {"TEST-USD": market}
 
@@ -161,13 +163,63 @@ async def test_start_aborts_when_mid_outside_bounds(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_start_uses_stats_when_order_book_empty(monkeypatch):
+    async def fake_get_markets():
+        market = SimpleNamespace(
+            name="TEST-USD",
+            trading_config=SimpleNamespace(price_precision=1),
+            market_stats=SimpleNamespace(bidPrice="99", askPrice="101"),
+        )
+        return {"TEST-USD": market}
+
+    async def fake_mass_cancel(markets=None):  # pragma: no cover - simple stub
+        return None
+
+    client = SimpleNamespace(get_markets=fake_get_markets, mass_cancel=fake_mass_cancel)
+    account = StubAccount(client)
+
+    async def fake_call_with_retries(fn, limiter=None):
+        return await fn()
+
+    monkeypatch.setattr("grid_main.call_with_retries", fake_call_with_retries)
+
+    async def fake_create_order_book(self):
+        return EmptyOrderBook()
+
+    monkeypatch.setattr(GridTrader, "_create_order_book", fake_create_order_book)
+
+    async def fake_update_grid(self):
+        return None
+
+    async def fake_refresh_loop(self):
+        return None
+
+    monkeypatch.setattr(GridTrader, "_update_grid", fake_update_grid)
+    monkeypatch.setattr(GridTrader, "_refresh_loop", fake_refresh_loop)
+
+    trader = GridTrader(
+        account=account,
+        market_name="TEST-USD",
+        grid_step=Decimal("10"),
+        level_count=4,
+        order_size_usd=Decimal("10"),
+        lower_bound=Decimal("90"),
+        upper_bound=Decimal("130"),
+    )
+
+    await trader.start()
+    sides = [slot.side for slot in trader._slots]
+    assert sides == [OrderSide.BUY, OrderSide.SELL, OrderSide.SELL, OrderSide.SELL]
+    await trader.stop()
+
+
+@pytest.mark.asyncio
 async def test_start_uses_ticker_when_order_book_empty(monkeypatch):
     async def fake_get_markets():
         market = SimpleNamespace(
             name="TEST-USD",
             trading_config=SimpleNamespace(price_precision=1),
-            last_price=None,
-            oracle_price=None,
+            market_stats=SimpleNamespace(),
         )
         return {"TEST-USD": market}
 
@@ -225,8 +277,7 @@ async def test_start_errors_when_all_price_sources_missing(monkeypatch):
         market = SimpleNamespace(
             name="TEST-USD",
             trading_config=SimpleNamespace(price_precision=1),
-            last_price=None,
-            oracle_price=None,
+            market_stats=SimpleNamespace(),
         )
         return {"TEST-USD": market}
 


### PR DESCRIPTION
## Summary
- derive midpoint from market stats when order book lacks prices
- drop direct last_price/oracle_price references
- test stats-derived mid price and ticker fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32ffe40a08330a97f6421baae63ae