### PR TITLE
Handle errors in refresh loop

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -267,39 +267,36 @@ class GridTrader:
         while not self._closing.is_set():
             try:
                 await self._update_grid()
-            except Exception:
-                logger.exception("refresh failed", exc_info=True)
-                await asyncio.sleep(REFRESH_INTERVAL_SEC)
-                continue
-            active_buys = sum(
-                1 for s in self._slots if s.side == OrderSide.BUY and s.external_id
-            )
-            active_sells = sum(
-                1 for s in self._slots if s.side == OrderSide.SELL and s.external_id
-            )
-            expected_total = max(0, len(self._slots) - 1)
-            if (active_buys + active_sells) < expected_total:
-                logger.warning(
-                    "grid refresh | active_total=%d expected_total=%d below expected; repopulating",
-                    active_buys + active_sells,
-                    expected_total,
-                )
-                try:
-                    await self._update_grid()
-                except Exception:
-                    logger.exception("refresh failed", exc_info=True)
                 active_buys = sum(
                     1 for s in self._slots if s.side == OrderSide.BUY and s.external_id
                 )
                 active_sells = sum(
                     1 for s in self._slots if s.side == OrderSide.SELL and s.external_id
                 )
-            logger.info(
-                "grid refresh | active_buys=%d active_sells=%d",
-                active_buys,
-                active_sells,
-            )
-            await asyncio.sleep(REFRESH_INTERVAL_SEC)
+                expected_total = max(0, len(self._slots) - 1)
+                if (active_buys + active_sells) < expected_total:
+                    logger.warning(
+                        "grid refresh | active_total=%d expected_total=%d below expected; repopulating",
+                        active_buys + active_sells,
+                        expected_total,
+                    )
+                    await self._update_grid()
+                    active_buys = sum(
+                        1 for s in self._slots if s.side == OrderSide.BUY and s.external_id
+                    )
+                    active_sells = sum(
+                        1 for s in self._slots if s.side == OrderSide.SELL and s.external_id
+                    )
+                logger.info(
+                    "grid refresh | active_buys=%d active_sells=%d",
+                    active_buys,
+                    active_sells,
+                )
+                await asyncio.sleep(REFRESH_INTERVAL_SEC)
+            except Exception:
+                logger.exception("refresh failed", exc_info=True)
+                await asyncio.sleep(0.5)
+                continue
 
     # ------------------------------------------------------------------
     def _is_edit_not_found(self, e: Exception) -> bool:


### PR DESCRIPTION
## Summary
- Wrap refresh loop grid updates and status checks in try/except
- Log refresh failures and delay briefly before retrying

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45780636083308fc78dda206f70d3