### PR TITLE
Handle task exceptions in grid update

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -710,7 +710,10 @@ class GridTrader:
             else:
                 tasks.append(self._cancel_slot(self._slots, i))
 
-        await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for idx, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.exception("[update_grid #%d] task failed", idx, exc_info=result)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure `_update_grid` captures asyncio task exceptions
- log each failed task with `logger.exception`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b458ee81d883309ac654bf28ac1501