### PR TITLE
Align grid order price with tick before size calculation

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -310,6 +310,12 @@ class GridTrader:
         if slot.external_id and slot.side == side:
             return
 
+        if self._tick is not None:
+            price = price.quantize(
+                self._tick,
+                rounding=ROUND_FLOOR if side == OrderSide.BUY else ROUND_CEILING,
+            )
+
         def _order_size(px: Decimal) -> Decimal:
             return self._market.trading_config.calculate_order_size_from_value(
                 self.order_size_usd, px


### PR DESCRIPTION
## Summary
- Quantize incoming order price to tick size in `_ensure_order`
- Ensure subsequent order size and placement use the adjusted price

## Testing
- `pytest tests/test_grid_invalid_price.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47b2057f083309f5223cb3eae43f1