### PR TITLE
Validate adjusted grid order prices against tick and bounds

### DIFF
--- a/tests/test_grid_invalid_price.py
+++ b/tests/test_grid_invalid_price.py
@@ -117,3 +117,46 @@ async def test_invalid_price_without_tick_clears_slot(monkeypatch, caplog):
     slot = trader._buy_slots[0]
     assert slot.external_id is None
     assert any("invalid price value" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_invalid_price_adjust_out_of_bounds(monkeypatch, caplog):
+    trader = GridTrader(
+        account=StubAccount(),
+        market_name="TEST-USD",
+        grid_step=Decimal("1"),
+        level_count=1,
+        order_size_usd=Decimal("10"),
+        lower_bound=Decimal("0"),
+        upper_bound=Decimal("100"),
+    )
+    trader._market = SimpleNamespace(
+        name="TEST-USD",
+        trading_config=SimpleNamespace(
+            calculate_order_size_from_value=lambda value, price: value / price,
+            min_order_size=Decimal("0"),
+        ),
+    )
+    trader._tick = Decimal("0.1")
+
+    calls = []
+
+    async def fake_create_and_place_order(**kwargs):
+        calls.append(kwargs)
+        raise FakeInvalidPrice()
+
+    trader.client = SimpleNamespace(create_and_place_order=fake_create_and_place_order)
+
+    async def fake_call_with_retries(fn, limiter=None):
+        return await fn()
+
+    monkeypatch.setattr("grid_main.call_with_retries", fake_call_with_retries)
+
+    caplog.set_level(logging.WARNING, logger="extended_bot")
+
+    await trader._ensure_order(trader._buy_slots, OrderSide.BUY, 0, Decimal("150.03"))
+
+    assert len(calls) == 1
+    slot = trader._buy_slots[0]
+    assert slot.external_id is None
+    assert any("adjusted price out of bounds" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- ensure adjusted grid order prices align with tick size and fall within configured min/max bounds
- log and skip placement when adjustment would violate constraints
- cover out-of-bounds adjustments with new test

## Testing
- `pytest tests/test_grid_invalid_price.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b496f536ec833090526845babcc48d