### PR TITLE
Precompute tick-aligned grid levels

### DIFF
--- a/tests/test_grid_on_fill.py
+++ b/tests/test_grid_on_fill.py
@@ -71,6 +71,6 @@ async def test_buy_fill_places_sell_order(monkeypatch):
 
     assert captured["side"] == OrderSide.SELL
     assert captured["idx"] == 1
-    assert captured["price"] == Decimal("2.3")
-    assert trader._slots[1].price == Decimal("2.3")
+    assert captured["price"] == Decimal("2.2")
+    assert trader._slots[1].price == Decimal("2.2")
     assert trader._slots[1].side == OrderSide.SELL


### PR DESCRIPTION
## Summary
- Cache all tick-aligned grid prices and snap `grid_step` to the market tick to avoid drift
- Reuse precomputed price levels on fills instead of recomputing offsets
- Adjust tests for new static price-level behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bd7c33648330af0653777341217c