### PR TITLE
Handle tick alignment with side-aware rounding

### DIFF
--- a/tests/test_grid_invalid_price.py
+++ b/tests/test_grid_invalid_price.py
@@ -67,7 +67,7 @@ async def test_invalid_price_adjusts_with_tick(monkeypatch, caplog):
 
     caplog.set_level(logging.INFO, logger="extended_bot")
 
-    await trader._ensure_order(trader._buy_slots, OrderSide.BUY, 0, Decimal("50.03"))
+    await trader._ensure_order(trader._buy_slots, OrderSide.BUY, 0, Decimal("50.07"))
 
     assert len(calls) == 1
     assert calls[0]["price"] == Decimal("50.0")
@@ -161,3 +161,92 @@ async def test_invalid_price_adjust_out_of_bounds(monkeypatch, caplog):
     slot = trader._buy_slots[0]
     assert slot.external_id is None
     assert any("adjusted price out of bounds" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_sell_price_rounds_up(monkeypatch, caplog):
+    trader = GridTrader(
+        account=StubAccount(),
+        market_name="TEST-USD",
+        grid_step=Decimal("1"),
+        level_count=1,
+        order_size_usd=Decimal("10"),
+        lower_bound=Decimal("0"),
+        upper_bound=Decimal("100"),
+    )
+    trader._market = SimpleNamespace(
+        name="TEST-USD",
+        trading_config=SimpleNamespace(
+            calculate_order_size_from_value=lambda value, price: value / price,
+            min_order_size=Decimal("0"),
+        ),
+    )
+    trader._tick = Decimal("0.1")
+
+    calls = []
+
+    async def fake_create_and_place_order(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(data=SimpleNamespace(status="PLACED"), error=None)
+
+    trader.client = SimpleNamespace(create_and_place_order=fake_create_and_place_order)
+
+    async def fake_call_with_retries(fn, limiter=None):
+        return await fn()
+
+    monkeypatch.setattr("grid_main.call_with_retries", fake_call_with_retries)
+
+    caplog.set_level(logging.INFO, logger="extended_bot")
+
+    await trader._ensure_order(trader._buy_slots, OrderSide.SELL, 0, Decimal("50.03"))
+
+    assert len(calls) == 1
+    assert calls[0]["price"] == Decimal("50.1")
+    slot = trader._buy_slots[0]
+    assert slot.price == Decimal("50.1")
+    assert slot.external_id is not None
+    assert slot.side == OrderSide.SELL
+    assert any("price adjusted to tick" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_price_not_multiple_of_tick_skips(monkeypatch, caplog):
+    trader = GridTrader(
+        account=StubAccount(),
+        market_name="TEST-USD",
+        grid_step=Decimal("1"),
+        level_count=1,
+        order_size_usd=Decimal("10"),
+        lower_bound=Decimal("0"),
+        upper_bound=Decimal("100"),
+    )
+    trader._market = SimpleNamespace(
+        name="TEST-USD",
+        trading_config=SimpleNamespace(
+            calculate_order_size_from_value=lambda value, price: value / price,
+            min_order_size=Decimal("0"),
+        ),
+    )
+    trader._tick = Decimal("0.3")
+
+    calls = []
+
+    async def fake_create_and_place_order(**kwargs):
+        calls.append(kwargs)
+        raise FakeInvalidPrice()
+
+    trader.client = SimpleNamespace(create_and_place_order=fake_create_and_place_order)
+
+    async def fake_call_with_retries(fn, limiter=None):
+        return await fn()
+
+    monkeypatch.setattr("grid_main.call_with_retries", fake_call_with_retries)
+
+    caplog.set_level(logging.WARNING, logger="extended_bot")
+
+    await trader._ensure_order(trader._buy_slots, OrderSide.BUY, 0, Decimal("50.07"))
+
+    assert len(calls) == 0
+    slot = trader._buy_slots[0]
+    assert slot.external_id is None
+    assert any("price not aligned to tick" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- round prices toward book side when snapping to tick
- warn and skip order placement if rounded price isn't tick aligned
- add tests for side-specific rounding and invalid tick multiples

## Testing
- `pytest tests/test_grid_invalid_price.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6747cb7448330b14c34c3fdb8748f