### PR TITLE
handle cancel timeouts via reconciliation

### DIFF
--- a/src/grid_main.py
+++ b/src/grid_main.py
@@ -737,31 +737,18 @@ class GridTrader:
             await call_with_retries(_cancel, limiter=self._limiter)
             slots[idx] = Slot(None, slot.price, slot.side)
         except Exception as e:
-            if not self._is_edit_not_found(e):
+            if self._is_edit_not_found(e):
+                slots[idx] = Slot(None, slot.price, slot.side)
+            else:
                 logger.exception(
                     "order cancel failed | market=%s idx=%d ext_id=%s",
                     self._market.name if self._market else "?",
                     idx,
                     slot.external_id,
                 )
-                if (
-                    slot.side
-                    and self.min_price <= slot.price <= self.max_price
-                ):
-                    try:
-                        await self._ensure_order(
-                            self._slots, slot.side, idx, slot.price
-                        )
-                        return
-                    except Exception:
-                        logger.exception(
-                            "order regeneration failed | market=%s idx=%d side=%s price=%s",
-                            self._market.name if self._market else "?",
-                            idx,
-                            slot.side.name if slot.side else None,
-                            str(slot.price),
-                        )
-            slots[idx] = Slot(None, slot.price, slot.side)
+                # leave the external_id so a future reconciliation can retry
+                slots[idx] = Slot(slot.external_id, slot.price, slot.side)
+                asyncio.create_task(self._update_grid())
 
     async def _switch_slot_to_side(self, idx: int, side: OrderSide) -> None:
         slot = self._slots[idx]


### PR DESCRIPTION
## Summary
- keep slot external_id when cancel_order fails and schedule reconciliation
- add test to ensure slots remain flagged until reconciliation clears them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b675c8bb608330ba517afe9d7958cf